### PR TITLE
updating field names for 'Group' and added a new 'Edit' interface

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -6,11 +6,12 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/scottlamb/luxor/protocol"
-	"golang.org/x/net/context"
 	"io/ioutil"
 	"net/http"
 	"time"
+
+	"github.com/scottlamb/luxor/protocol"
+	"golang.org/x/net/context"
 )
 
 // *Controller implements protocol.Controller
@@ -167,6 +168,14 @@ func (c *Controller) GroupListGet(ctx context.Context, req *protocol.GroupListGe
 func (c *Controller) GroupListRename(ctx context.Context, req *protocol.GroupListRenameRequest) (*protocol.GroupListRenameResponse, error) {
 	resp := &protocol.GroupListRenameResponse{}
 	if err := c.request(ctx, "GroupListRename", req, resp); err != nil {
+		return nil, err
+	}
+	return resp, protocol.ErrorForStatus(resp.Status)
+}
+
+func (c *Controller) GroupListEdit(ctx context.Context, req *protocol.GroupListEditRequest) (*protocol.GroupListEditResponse, error) {
+	resp := &protocol.GroupListEditResponse{}
+	if err := c.request(ctx, "GroupListEdit", req, resp); err != nil {
 		return nil, err
 	}
 	return resp, protocol.ErrorForStatus(resp.Status)

--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -48,6 +48,7 @@ package protocol
 import (
 	"errors"
 	"fmt"
+
 	"golang.org/x/net/context"
 )
 
@@ -202,9 +203,10 @@ type FlashLightsResponse struct {
 }
 
 type Group struct {
-	GroupNumber uint8
-	Intensity   uint8
-	Name        string
+	Name        string `json:"Name"`
+	GroupNumber uint8  `json:"Grp"`
+	Intensity   uint8  `json:"Inten"`
+	Color       uint8  `json:"Colr"`
 }
 
 type GroupListAddRequest struct {

--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -89,6 +89,9 @@ type Controller interface {
 	// GroupListRename renames a group.
 	GroupListRename(ctx context.Context, request *GroupListRenameRequest) (response *GroupListRenameResponse, err error)
 
+	// GroupListEdit updates a group values (intensity, color).
+	GroupListEdit(ctx context.Context, request *GroupListEditRequest) (response *GroupListEditResponse, err error)
+
 	// GroupListReorder reorders groups.
 	GroupListReorder(ctx context.Context, request *GroupListReorderRequest) (response *GroupListReorderResponse, err error)
 
@@ -257,6 +260,22 @@ type GroupListRenameRequest struct {
 
 type GroupListRenameResponse struct {
 	// Status will be StatusGroupNameInUse if the name is taken.
+	Status int
+}
+
+// GroupListEditRequest allows editing/saving of Group number and color assignments
+// For updating only the name, use GroupListRename
+// For updating all at the same time, call Rename first and (on success),
+// use the Name key to then call Edit.
+type GroupListEditRequest struct {
+	Name        string
+	GroupNumber uint8
+	Color       uint8
+}
+
+// GroupListEditResponse -- response counterpart
+type GroupListEditResponse struct {
+	// Status will be StatusPreconditionFailed if the name does not exist.
 	Status int
 }
 


### PR DESCRIPTION
The field names have been updated to unmarshall correctly. I've kept the mnemonic names to make it more readable.

<img width="319" alt="Screenshot 2020-12-01 at 4 31 57 PM" src="https://user-images.githubusercontent.com/1910451/100812820-c8dd9880-33f2-11eb-938e-4e28fea3d206.png">
